### PR TITLE
feat menus-endpoints and fix un creation of restaurant

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { HealthModule } from './modules/health/health.module'
 import { AuthGuard } from './guards/auth.guard'
 import { RolesInterceptor } from './interceptors/role.interceptor'
 import { RestaurantsModule } from './modules/restaurants/restaurants.module'
+import { MenusModule } from './modules/menus/menus.module'
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { RestaurantsModule } from './modules/restaurants/restaurants.module'
     AuthModule,
     UsersModule,
     RestaurantsModule,
+    MenusModule,
     S3Module,
     HealthModule
   ],

--- a/api/src/modules/menus/dtos/create-menu-request.dto.ts
+++ b/api/src/modules/menus/dtos/create-menu-request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { IsArray, ArrayNotEmpty, IsUUID } from 'class-validator'
+
+export class CreateMenuRequestDto {
+  @ApiProperty({ description: 'Restaurant ID that will own the menu', example: 'c7c2f6a0-9e7c-4a8d-9f0b-3a8f8a4d6a1b', format: 'uuid' })
+  @IsUUID('4', { message: 'restaurantId must be a valid UUID' })
+  restaurantId: string
+
+  @ApiProperty({ description: 'List of product IDs to associate to this menu', isArray: true, type: String, example: ['7acb9b1d-31c0-4b1d-9a1a-2a3b4c5d6e7f'] })
+  @IsArray({ message: 'productIds must be an array' })
+  @ArrayNotEmpty({ message: 'productIds cannot be empty' })
+  @IsUUID('4', { each: true, message: 'each productId must be a valid UUID' })
+  productIds: string[]
+}

--- a/api/src/modules/menus/dtos/update-menu-request.dto.ts
+++ b/api/src/modules/menus/dtos/update-menu-request.dto.ts
@@ -1,0 +1,17 @@
+import { ApiPropertyOptional } from '@nestjs/swagger'
+import { IsArray, IsEnum, IsOptional, IsUUID } from 'class-validator'
+
+import { MenuStatus } from '../enums/menu-status.enum'
+
+export class UpdateMenuRequestDto {
+  @ApiPropertyOptional({ enum: MenuStatus, description: 'Menu status' })
+  @IsEnum(MenuStatus)
+  @IsOptional()
+  status?: MenuStatus
+
+  @ApiPropertyOptional({ type: [String], description: 'New list of product IDs for the menu', isArray: true })
+  @IsArray()
+  @IsUUID('4', { each: true })
+  @IsOptional()
+  productIds?: string[]
+}

--- a/api/src/modules/menus/entities/menu.entity.ts
+++ b/api/src/modules/menus/entities/menu.entity.ts
@@ -1,7 +1,9 @@
-import { Restaurant } from 'src/modules/restaurants/entities/restaurant.entity'
 import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
-import { MenuStatus } from '../enums/menu-status.enum'
+
+import { Restaurant } from 'src/modules/restaurants/entities/restaurant.entity'
 import { Product } from 'src/modules/products/entities/product.entity'
+
+import { MenuStatus } from '../enums/menu-status.enum'
 
 @Entity('menus')
 export class Menu {
@@ -11,7 +13,7 @@ export class Menu {
   @ManyToOne(() => Restaurant, (restaurant) => restaurant.menus)
   restaurant: Restaurant
 
-  @Column('enum', { enum: MenuStatus })
+  @Column('enum', { enum: MenuStatus, default: MenuStatus.ACTIVE })
   status: MenuStatus
 
   @OneToMany(() => Product, (product) => product.menu)

--- a/api/src/modules/menus/menus.controller.ts
+++ b/api/src/modules/menus/menus.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Post, Param, Get, Query } from '@nestjs/common'
+import { ApiBearerAuth, ApiBody, ApiHeader, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger'
+import { UserRoles } from '@shared/modules/users/enums/roles.enum'
+
+import { Roles } from 'src/decorators/roles.decorator'
+import { UserId } from 'src/decorators/user-id.decorator'
+import { Public } from 'src/decorators/public.decorator'
+
+import { MenusService } from './menus.service'
+import { CreateMenuRequestDto } from './dtos/create-menu-request.dto'
+import { UpdateMenuRequestDto } from './dtos/update-menu-request.dto'
+
+@ApiTags('Menus')
+@Controller('menus')
+export class MenusController {
+  constructor(private readonly menusService: MenusService) {}
+  @Post('create')
+  @ApiOperation({ summary: 'Crear un menú de un restaurante' })
+  @ApiBearerAuth()
+  @Roles(UserRoles.SuperAdmin, UserRoles.Tenant)
+  @ApiHeader({ name: 'x-refresh-token' })
+  @ApiHeader({ name: 'x-id-token' })
+  @ApiBody({ type: CreateMenuRequestDto })
+  async createMenu(@UserId() userId: string, @Body() body: CreateMenuRequestDto) {
+    return await this.menusService.createMenu(userId, body)
+  }
+
+  @Post('update/:id')
+  @ApiOperation({ summary: 'Actualizar un menú de un restaurante' })
+  @ApiBearerAuth()
+  @Roles(UserRoles.SuperAdmin, UserRoles.Tenant)
+  @ApiHeader({ name: 'x-refresh-token' })
+  @ApiHeader({ name: 'x-id-token' })
+  @ApiParam({ name: 'id', required: true })
+  @ApiBody({ type: UpdateMenuRequestDto })
+  async updateMenu(@UserId() userId: string, @Body() body: UpdateMenuRequestDto, @Param('id') id: string) {
+    return await this.menusService.updateMenu(userId, id, body)
+  }
+
+  @Get('for-restaurant')
+  @Public()
+  @ApiOperation({ summary: 'Obtener el menú activo de un restaurante' })
+  @ApiQuery({ name: 'restaurantId', required: true })
+  async getMenuForRestaurant(@Query('restaurantId') restaurantId: string) {
+    return await this.menusService.findActiveMenuForRestaurant(restaurantId)
+  }
+}

--- a/api/src/modules/menus/menus.module.ts
+++ b/api/src/modules/menus/menus.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+
+import { Restaurant } from 'src/modules/restaurants/entities/restaurant.entity'
+import { Product } from 'src/modules/products/entities/product.entity'
+
+import { Menu } from './entities/menu.entity'
+import { MenusService } from './menus.service'
+import { MenusController } from './menus.controller'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Menu, Restaurant, Product])],
+  controllers: [MenusController],
+  providers: [MenusService],
+  exports: [MenusService]
+})
+export class MenusModule {}

--- a/api/src/modules/menus/menus.service.ts
+++ b/api/src/modules/menus/menus.service.ts
@@ -2,6 +2,7 @@ import { Repository, In } from 'typeorm'
 import { HttpStatus, Injectable, Logger } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { ResponseDto } from '@shared/helpers/response.helper'
+import { MenuCodes, MenuMessages } from '@shared/modules/menus/menus.constants'
 
 import { Restaurant } from 'src/modules/restaurants/entities/restaurant.entity'
 import { Product } from 'src/modules/products/entities/product.entity'
@@ -22,15 +23,15 @@ export class MenusService {
   ) {}
 
   async createMenu(userId: string, body: CreateMenuRequestDto): Promise<ResponseDto<Menu>> {
-    this.logger.log('Creating menu...')
+    this.logger.log('Creating menu for user ' + userId + '...')
 
     const restaurant = await this.restaurantsRepository.findOne({ where: { id: body.restaurantId }, relations: ['user'] })
 
     if (!restaurant || restaurant.user.id !== userId) {
       return {
         success: false,
-        code: 'MENU_RESTAURANT_NOT_OWNED',
-        message: 'Restaurant does not exist or is not owned by the user',
+        code: MenuCodes.MENU_RESTAURANT_NOT_OWNED,
+        message: MenuMessages[MenuCodes.MENU_RESTAURANT_NOT_OWNED].en,
         httpCode: HttpStatus.FORBIDDEN,
         data: null
       }
@@ -41,8 +42,8 @@ export class MenusService {
     if (products.length !== body.productIds.length) {
       return {
         success: false,
-        code: 'MENU_PRODUCTS_NOT_FOUND',
-        message: 'Some products were not found for this restaurant',
+        code: MenuCodes.MENU_PRODUCTS_NOT_FOUND,
+        message: MenuMessages[MenuCodes.MENU_PRODUCTS_NOT_FOUND].en,
         httpCode: HttpStatus.BAD_REQUEST,
         data: null
       }
@@ -63,8 +64,8 @@ export class MenusService {
 
     return {
       success: true,
-      code: 'MENU_CREATED',
-      message: 'Menu created successfully',
+      code: MenuCodes.MENU_CREATED,
+      message: MenuMessages[MenuCodes.MENU_CREATED].en,
       httpCode: HttpStatus.CREATED,
       data: menu
     }
@@ -78,8 +79,8 @@ export class MenusService {
     if (!menu) {
       return {
         success: false,
-        code: 'MENU_NOT_FOUND',
-        message: 'Menu not found',
+        code: MenuCodes.MENU_NOT_FOUND,
+        message: MenuMessages[MenuCodes.MENU_NOT_FOUND].en,
         httpCode: HttpStatus.NOT_FOUND,
         data: null
       }
@@ -88,8 +89,8 @@ export class MenusService {
     if (menu.restaurant.user.id !== userId) {
       return {
         success: false,
-        code: 'MENU_NOT_OWNED',
-        message: 'Menu is not owned by this user',
+        code: MenuCodes.MENU_NOT_OWNED,
+        message: MenuMessages[MenuCodes.MENU_NOT_OWNED].en,
         httpCode: HttpStatus.FORBIDDEN,
         data: null
       }
@@ -106,8 +107,8 @@ export class MenusService {
       if (products.length !== body.productIds.length) {
         return {
           success: false,
-          code: 'MENU_PRODUCTS_NOT_FOUND',
-          message: 'Some products were not found for this restaurant',
+          code: MenuCodes.MENU_PRODUCTS_NOT_FOUND,
+          message: MenuMessages[MenuCodes.MENU_PRODUCTS_NOT_FOUND].en,
           httpCode: HttpStatus.BAD_REQUEST,
           data: null
         }
@@ -132,8 +133,8 @@ export class MenusService {
 
     return {
       success: true,
-      code: 'MENU_UPDATED',
-      message: 'Menu updated successfully',
+      code: MenuCodes.MENU_UPDATED,
+      message: MenuMessages[MenuCodes.MENU_UPDATED].en,
       httpCode: HttpStatus.OK,
       data: menu
     }
@@ -147,8 +148,8 @@ export class MenusService {
     if (!menu) {
       return {
         success: true,
-        code: 'MENU_NOT_FOUND',
-        message: 'No active menu found for this restaurant',
+        code: MenuCodes.MENU_ACTIVE_NOT_FOUND,
+        message: MenuMessages[MenuCodes.MENU_ACTIVE_NOT_FOUND].en,
         httpCode: HttpStatus.OK,
         data: null
       }
@@ -156,8 +157,8 @@ export class MenusService {
 
     return {
       success: true,
-      code: 'MENU_FOUND',
-      message: 'Active menu found',
+      code: MenuCodes.MENU_FOUND,
+      message: MenuMessages[MenuCodes.MENU_FOUND].en,
       httpCode: HttpStatus.OK,
       data: menu
     }

--- a/api/src/modules/menus/menus.service.ts
+++ b/api/src/modules/menus/menus.service.ts
@@ -1,0 +1,165 @@
+import { Repository, In } from 'typeorm'
+import { HttpStatus, Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { ResponseDto } from '@shared/helpers/response.helper'
+
+import { Restaurant } from 'src/modules/restaurants/entities/restaurant.entity'
+import { Product } from 'src/modules/products/entities/product.entity'
+
+import { Menu } from './entities/menu.entity'
+import { MenuStatus } from './enums/menu-status.enum'
+import { CreateMenuRequestDto } from './dtos/create-menu-request.dto'
+import { UpdateMenuRequestDto } from './dtos/update-menu-request.dto'
+
+@Injectable()
+export class MenusService {
+  private readonly logger = new Logger(MenusService.name)
+
+  constructor(
+    @InjectRepository(Menu) private readonly menusRepository: Repository<Menu>,
+    @InjectRepository(Restaurant) private readonly restaurantsRepository: Repository<Restaurant>,
+    @InjectRepository(Product) private readonly productsRepository: Repository<Product>
+  ) {}
+
+  async createMenu(userId: string, body: CreateMenuRequestDto): Promise<ResponseDto<Menu>> {
+    this.logger.log('Creating menu...')
+
+    const restaurant = await this.restaurantsRepository.findOne({ where: { id: body.restaurantId }, relations: ['user'] })
+
+    if (!restaurant || restaurant.user.id !== userId) {
+      return {
+        success: false,
+        code: 'MENU_RESTAURANT_NOT_OWNED',
+        message: 'Restaurant does not exist or is not owned by the user',
+        httpCode: HttpStatus.FORBIDDEN,
+        data: null
+      }
+    }
+
+    const products = await this.productsRepository.find({ where: { id: In(body.productIds), restaurant: { id: restaurant.id } }, relations: ['restaurant'] })
+
+    if (products.length !== body.productIds.length) {
+      return {
+        success: false,
+        code: 'MENU_PRODUCTS_NOT_FOUND',
+        message: 'Some products were not found for this restaurant',
+        httpCode: HttpStatus.BAD_REQUEST,
+        data: null
+      }
+    }
+
+    const menu = this.menusRepository.create({
+      restaurant,
+      status: MenuStatus.ACTIVE
+    })
+
+    await this.menusRepository.save(menu)
+
+    // set owning side on products
+    for (const product of products) {
+      product.menu = menu
+    }
+    await this.productsRepository.save(products)
+
+    return {
+      success: true,
+      code: 'MENU_CREATED',
+      message: 'Menu created successfully',
+      httpCode: HttpStatus.CREATED,
+      data: menu
+    }
+  }
+
+  async updateMenu(userId: string, id: string, body: UpdateMenuRequestDto): Promise<ResponseDto<Menu>> {
+    this.logger.log(`Updating menu for restaurant ${id}...`)
+
+    const menu = await this.menusRepository.findOne({ where: { id }, relations: ['restaurant', 'restaurant.user', 'products'] })
+
+    if (!menu) {
+      return {
+        success: false,
+        code: 'MENU_NOT_FOUND',
+        message: 'Menu not found',
+        httpCode: HttpStatus.NOT_FOUND,
+        data: null
+      }
+    }
+
+    if (menu.restaurant.user.id !== userId) {
+      return {
+        success: false,
+        code: 'MENU_NOT_OWNED',
+        message: 'Menu is not owned by this user',
+        httpCode: HttpStatus.FORBIDDEN,
+        data: null
+      }
+    }
+
+    if (body.status) {
+      menu.status = body.status
+    }
+
+    if (body.productIds) {
+      // validate new products belong to same restaurant
+      const products = await this.productsRepository.find({ where: { id: In(body.productIds), restaurant: { id: menu.restaurant.id } }, relations: ['restaurant'] })
+
+      if (products.length !== body.productIds.length) {
+        return {
+          success: false,
+          code: 'MENU_PRODUCTS_NOT_FOUND',
+          message: 'Some products were not found for this restaurant',
+          httpCode: HttpStatus.BAD_REQUEST,
+          data: null
+        }
+      }
+
+      // clear current associations
+      if (menu.products.length > 0) {
+        for (const p of menu.products) {
+          p.menu = null as unknown as Menu // break relation
+        }
+        await this.productsRepository.save(menu.products)
+      }
+
+      for (const product of products) {
+        product.menu = menu
+      }
+      await this.productsRepository.save(products)
+      menu.products = products
+    }
+
+    await this.menusRepository.save(menu)
+
+    return {
+      success: true,
+      code: 'MENU_UPDATED',
+      message: 'Menu updated successfully',
+      httpCode: HttpStatus.OK,
+      data: menu
+    }
+  }
+
+  async findActiveMenuForRestaurant(restaurantId: string): Promise<ResponseDto<Menu>> {
+    this.logger.log(`Finding active menu for restaurant ${restaurantId}...`)
+
+    const menu = await this.menusRepository.findOne({ where: { restaurant: { id: restaurantId }, status: MenuStatus.ACTIVE }, relations: ['products', 'restaurant'] })
+
+    if (!menu) {
+      return {
+        success: true,
+        code: 'MENU_NOT_FOUND',
+        message: 'No active menu found for this restaurant',
+        httpCode: HttpStatus.OK,
+        data: null
+      }
+    }
+
+    return {
+      success: true,
+      code: 'MENU_FOUND',
+      message: 'Active menu found',
+      httpCode: HttpStatus.OK,
+      data: menu
+    }
+  }
+}

--- a/api/src/modules/restaurants/dtos/create-restaurant-request.dto.ts
+++ b/api/src/modules/restaurants/dtos/create-restaurant-request.dto.ts
@@ -1,7 +1,7 @@
 import { ICreateRestaurantsRequest } from '@shared/modules/restaurants/interfaces/create-restaurants-request.interface'
 import { RestaurantStatus } from '@shared/modules/restaurants/enums/restaurant.status.enum'
 import { ApiProperty } from '@nestjs/swagger'
-import { IsBoolean, IsNotEmpty, IsString } from 'class-validator'
+import { IsBoolean, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator'
 
 export class CreateRestaurantRequestDto implements ICreateRestaurantsRequest {
   @ApiProperty({
@@ -37,5 +37,16 @@ export class CreateRestaurantRequestDto implements ICreateRestaurantsRequest {
     required: false,
     enum: RestaurantStatus
   })
+  @IsEnum(RestaurantStatus)
+  @IsOptional()
   status?: RestaurantStatus
+
+  @ApiProperty({
+    description: 'Logo image of the restaurant',
+    required: false,
+    type: 'string',
+    format: 'binary'
+  })
+  @IsOptional()
+  file?: any
 }

--- a/api/src/modules/restaurants/restaurants.controller.ts
+++ b/api/src/modules/restaurants/restaurants.controller.ts
@@ -24,40 +24,7 @@ export class RestaurantsController {
   @ApiHeader({ name: 'x-id-token' })
   @ApiOperation({ summary: 'Crear un restaurante' })
   @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      required: ['name', 'isOpen', 'addressLocation'],
-      properties: {
-        name: {
-          type: 'string',
-          example: 'Pasta Palace',
-          description: 'The name of the restaurant'
-        },
-        isOpen: {
-          type: 'boolean',
-          example: true,
-          description: 'Indicates if the restaurant is open'
-        },
-        address: {
-          type: 'string',
-          example: '123 Pasta St, Food City',
-          description: 'The location of the restaurant'
-        },
-        status: {
-          type: 'string',
-          enum: Object.values(RestaurantStatus),
-          description: 'The status of the restaurant (optional)',
-          example: RestaurantStatus.PENDING_APPROVAL
-        },
-        file: {
-          type: 'string',
-          format: 'binary',
-          description: 'Logo image of the restaurant'
-        }
-      }
-    }
-  })
+  @ApiBody({ type: CreateRestaurantRequestDto })
   @UseInterceptors(FileInterceptor('file'))
   async createRestaurant(@UserId() userId: string, @Body() body: CreateRestaurantRequestDto, @UploadedFile() file: Express.Multer.File) {
     return await this.restaurantsService.createRestaurant(userId, body, file)

--- a/shared/modules/menus/menus.constants.ts
+++ b/shared/modules/menus/menus.constants.ts
@@ -1,0 +1,47 @@
+export enum MenuCodes {
+  MENU_CREATED = 'MENU_CREATED',
+  MENU_UPDATED = 'MENU_UPDATED',
+  MENU_FOUND = 'MENU_FOUND',
+  MENU_NOT_FOUND = 'MENU_NOT_FOUND',
+  MENU_ACTIVE_NOT_FOUND = 'MENU_ACTIVE_NOT_FOUND',
+  MENU_RESTAURANT_NOT_OWNED = 'MENU_RESTAURANT_NOT_OWNED',
+  MENU_PRODUCTS_NOT_FOUND = 'MENU_PRODUCTS_NOT_FOUND',
+  MENU_NOT_OWNED = 'MENU_NOT_OWNED'
+}
+
+export const MenuMessages: Record<MenuCodes, Record<string, string>> = {
+  [MenuCodes.MENU_CREATED]: {
+    en: 'Menu created successfully',
+    es: 'Menú creado exitosamente'
+  },
+  [MenuCodes.MENU_UPDATED]: {
+    en: 'Menu updated successfully',
+    es: 'Menú actualizado exitosamente'
+  },
+  [MenuCodes.MENU_FOUND]: {
+    en: 'Active menu found',
+    es: 'Menú activo encontrado'
+  },
+  [MenuCodes.MENU_NOT_FOUND]: {
+    en: 'Menu not found',
+    es: 'Menú no encontrado'
+  },
+  [MenuCodes.MENU_ACTIVE_NOT_FOUND]: {
+    en: 'No active menu found for this restaurant',
+    es: 'No se encontró un menú activo para este restaurante'
+  },
+  [MenuCodes.MENU_RESTAURANT_NOT_OWNED]: {
+    en: 'Restaurant does not exist or is not owned by the user',
+    es: 'El restaurante no existe o no pertenece al usuario'
+  },
+  [MenuCodes.MENU_PRODUCTS_NOT_FOUND]: {
+    en: 'Some products were not found for this restaurant',
+    es: 'Algunos productos no se encontraron para este restaurante'
+  },
+  [MenuCodes.MENU_NOT_OWNED]: {
+    en: 'Menu is not owned by this user',
+    es: 'El menú no pertenece a este usuario'
+  }
+}
+
+


### PR DESCRIPTION
* Se actualizó CreateRestaurantRequestDto para aceptar status como opcional con @IsEnum(RestaurantStatus) y file como opcional (multipart, format: binary) para cumplir con el ValidationPipe con whitelist y forbidNonWhitelisted.

* Se corrigió el @ApiBody del endpoint POST /restaurants/create reemplazando addressLocation por address en los campos requeridos y documentando correctamente status y file.

* Se ajustó RestaurantsService.createRestaurant para:
Hacer opcional la subida del logo a S3 (solo se intenta si llega file), evitando errores al acceder a file.buffer.
Asociar el restaurante al usuario autenticado asignando la relación user con userId en la creación.

* Se mantiene la semántica de respuestas usando RestaurantCodes y RestaurantMessages, incluyendo el caso de éxito parcial cuando no se pudo subir el logo (RESTAURANT_CREATED_WITHOUT_LOGO).

* Se resolvieron los errores de validación previos (“property status/file should not exist”) al alinear Swagger, DTOs y validadores.

* DTOs: CreateMenuRequestDto (restaurantId, productIds) y UpdateMenuRequestDto (status?, productIds?).
* POST /menus/create: autenticado; valida propietario del restaurante; crea menú en ACTIVE y asocia products.
* POST /menus/update/:id: autenticado; valida propietario del menú; actualiza status y/o reasigna products.
* GET /menus/for-restaurant: público; devuelve menú ACTIVE del restaurante con products (o null si no hay).

Extras: Menu.status default ACTIVE; MenusModule agregado e importado en AppModule; Swagger usa los DTOs.