### PR TITLE
fix: autenticacion de users/staff y respuestas de find all staff

### DIFF
--- a/api/src/decorators/roles.decorator.ts
+++ b/api/src/decorators/roles.decorator.ts
@@ -6,4 +6,4 @@ import { SetMetadata } from '@nestjs/common'
 export const ROLES_KEY = 'roles'
 
 // Decorador para establecer los roles permitidos para ejecutar la petición
-export const Roles = (...roles: UserRoles[] | RestaurantStaffMemberRole[]) => SetMetadata(ROLES_KEY, roles)
+export const Roles = (...roles: (UserRoles | RestaurantStaffMemberRole)[]) => SetMetadata(ROLES_KEY, roles)

--- a/api/src/modules/auth/auth.controller.ts
+++ b/api/src/modules/auth/auth.controller.ts
@@ -1,26 +1,8 @@
 import { ApiBearerAuth, ApiHeader, ApiOperation, ApiTags } from '@nestjs/swagger'
 import { Body, Controller, Post, Res } from '@nestjs/common'
 import { Response } from 'express'
-
-import { Public } from 'src/decorators/public.decorator'
-import { Roles } from 'src/decorators/roles.decorator'
-import { AccessToken } from 'src/decorators/access-token.decorator'
-import { UserId } from 'src/decorators/user-id.decorator'
 import { ResponseDto } from '@shared/helpers/response.helper'
-
 import { UserRoles } from '@shared/modules/users/enums/roles.enum'
-
-import { ResendCodeRequestDto } from './dtos/resend-code-sign-up.dto'
-import { AuthService } from './auth.service'
-import { ConfirmSignUpRequestDto } from './dtos/confirm-sign-up.dto'
-import { ForgotPasswordRequestDto } from './dtos/forgot-password.dto'
-import { ResetPasswordRequestDto } from './dtos/reset-password.dto'
-import { ChangeEmailRequestDto } from './dtos/change-email.dto'
-import { ChangePasswordRequestDto } from './dtos/change-password.dto'
-import { ConfirmChangeEmailRequestDto } from './dtos/confirm-change-email.dto'
-import { ValidatePasswordRequestDto } from './dtos/validate-password.dto'
-import { SignInRequestDto } from './dtos/sign-in-request.dto'
-import { SignUpRequestDto } from './dtos/sign-up-request.dto'
 import { ISignInResponse } from '@shared/modules/auth/interfaces/sign-in-response.interface'
 import { ISignUpResponse } from '@shared/modules/auth/interfaces/sign-up-response.interface'
 import { IConfirmSignUpResponse } from '@shared/modules/auth/interfaces/confirm-sign-up-response.interface'
@@ -33,13 +15,29 @@ import { IConfirmChangeEmailResponse } from '@shared/modules/auth/interfaces/con
 import { IResendCodeResponse } from '@shared/modules/auth/interfaces/resend-code-response.interface'
 import { IValidatePasswordResponse } from '@shared/modules/auth/interfaces/validate-password-response.interface'
 import { AUTH_BASE_PATH, AUTH_PATHS } from '@shared/modules/auth/auth.endpoints'
+import { RestaurantStaffMemberRole } from '@shared/modules/restaurants/enums/restaurant-staff-member-roles.enum'
+
+import { Public } from 'src/decorators/public.decorator'
+import { Roles } from 'src/decorators/roles.decorator'
+import { AccessToken } from 'src/decorators/access-token.decorator'
+import { UserId } from 'src/decorators/user-id.decorator'
+
+import { ResendCodeRequestDto } from './dtos/resend-code-sign-up.dto'
+import { AuthService } from './auth.service'
+import { ConfirmSignUpRequestDto } from './dtos/confirm-sign-up.dto'
+import { ForgotPasswordRequestDto } from './dtos/forgot-password.dto'
+import { ResetPasswordRequestDto } from './dtos/reset-password.dto'
+import { ChangeEmailRequestDto } from './dtos/change-email.dto'
+import { ChangePasswordRequestDto } from './dtos/change-password.dto'
+import { ConfirmChangeEmailRequestDto } from './dtos/confirm-change-email.dto'
+import { ValidatePasswordRequestDto } from './dtos/validate-password.dto'
+import { SignInRequestDto } from './dtos/sign-in-request.dto'
+import { SignUpRequestDto } from './dtos/sign-up-request.dto'
 
 @ApiTags('Auth')
 @Controller(AUTH_BASE_PATH)
 export class AuthController {
-  constructor(
-    private authService: AuthService
-  ) { }
+  constructor(private readonly authService: AuthService) {}
 
   @ApiOperation({ summary: 'User sign in' })
   @Public()
@@ -77,7 +75,7 @@ export class AuthController {
   }
 
   @ApiOperation({ summary: 'Sign out the user' })
-  @Roles(UserRoles.SuperAdmin, UserRoles.Tenant)
+  @Roles(UserRoles.SuperAdmin, UserRoles.Tenant, RestaurantStaffMemberRole.CASHIER, RestaurantStaffMemberRole.COOK, RestaurantStaffMemberRole.WAITER, RestaurantStaffMemberRole.OTHER)
   @ApiBearerAuth()
   @ApiHeader({ name: 'x-refresh-token' })
   @ApiHeader({ name: 'x-id-token' })

--- a/api/src/modules/restaurants/restaurants.service.ts
+++ b/api/src/modules/restaurants/restaurants.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm'
 import { RestaurantCodes, RestaurantMessages } from '@shared/modules/restaurants/restaurants.contants'
 import { RestaurantStatus } from '@shared/modules/restaurants/enums/restaurant.status.enum'
 import { IFindAllRestaurantsResponse } from '@shared/modules/restaurants/interfaces/find-all-restaurants-response.interface'
+import { IFindAllStaffResponse } from '@shared/modules/restaurants/interfaces/find-all-staff-response.interface'
 
 import { User } from 'src/modules/users/entities/user.entity'
 
@@ -292,12 +293,21 @@ export class RestaurantsService {
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     this.logger.log(`Found ${staffMembers.length} staff members for restaurant: ${id}`)
 
+    const response: IFindAllStaffResponse[] = staffMembers.map((staff) => ({
+      id: staff.id,
+      name: staff.name,
+      lastName: staff.lastName,
+      email: staff.email,
+      role: staff.role,
+      isActive: staff.isActive
+    }))
+
     return {
       success: true,
       code: RestaurantCodes.STAFFS_FOUND,
       message: RestaurantMessages[RestaurantCodes.STAFFS_FOUND].en,
       httpCode: HttpStatus.OK,
-      data: staffMembers
+      data: response
     }
   }
 

--- a/shared/modules/restaurants/interfaces/find-all-staff-response.interface.ts
+++ b/shared/modules/restaurants/interfaces/find-all-staff-response.interface.ts
@@ -1,0 +1,10 @@
+import { RestaurantStaffMemberRole } from '../enums/restaurant-staff-member-roles.enum'
+
+export interface IFindAllStaffResponse {
+    id: string
+    name: string
+    lastName: string
+    email: string
+    role: RestaurantStaffMemberRole
+    isActive: boolean
+}


### PR DESCRIPTION
- Se ajusto el decorator Roles para manejar múltiples enums de roles. UserRoles y RestaurantStaffMemberRole

- En el modulo Auth se ajusto Sign out para que tanto users como staffs puedan cerrar sesión

- En el modulo cognito se creo el método createStaffUser para crear los staff en cognito y automáticamente tener su email confirmado. también se ajusto el método createStaff para usar este nuevo método.

- Se ajusto la respuesta de findAllStaff para solo retornar la info necesaria y no exponer data sensible como el cognito id