### PR TITLE
feat: modulo restaurants - CRUD horarios

### DIFF
--- a/api/src/modules/restaurants/dtos/create-restaurant-schedule.dto.ts
+++ b/api/src/modules/restaurants/dtos/create-restaurant-schedule.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { DaysSchedule } from '@shared/modules/restaurants/enums/days-schedule.enum'
+import { IsEnum, IsString, Matches } from 'class-validator'
+
+export class CreateRestaurantScheduleDto {
+  @ApiProperty({
+    example: DaysSchedule.MONDAY,
+    description: 'The day of the week',
+    required: true,
+    enum: DaysSchedule
+  })
+  @IsEnum(DaysSchedule)
+  dayOfWeek: DaysSchedule
+
+  @ApiProperty({
+    example: '09:00',
+    description: 'The opening time of the restaurant (format HH:mm)',
+    required: true
+  })
+  @IsString()
+  @Matches(/^([0-1][0-9]|2[0-3]):[0-5][0-9]$/, {
+    message: 'openTime must be in format HH:mm (00:00-23:59)'
+  })
+  openTime: string
+
+  @ApiProperty({
+    example: '22:00',
+    description: 'The closing time of the restaurant (format HH:mm)',
+    required: true
+  })
+  @IsString()
+  @Matches(/^([0-1][0-9]|2[0-3]):[0-5][0-9]$/, {
+    message: 'closeTime must be in format HH:mm (00:00-23:59)'
+  })
+  closeTime: string
+}

--- a/api/src/modules/restaurants/entities/restaurant-schedule.entity.ts
+++ b/api/src/modules/restaurants/entities/restaurant-schedule.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
 import { DaysSchedule } from '@shared/modules/restaurants/enums/days-schedule.enum'
 
 import { Restaurant } from './restaurant.entity'
@@ -19,4 +19,16 @@ export class RestaurantSchedule {
 
   @Column('time')
   closeTime: string
+
+  @CreateDateColumn({
+    type: 'timestamp without time zone',
+    default: () => 'CURRENT_TIMESTAMP'
+  })
+  createdAt: Date
+
+  @UpdateDateColumn({
+    type: 'timestamp without time zone',
+    default: () => 'CURRENT_TIMESTAMP'
+  })
+  updatedAt: Date
 }

--- a/api/src/modules/restaurants/entities/restaurant-schedule.entity.ts
+++ b/api/src/modules/restaurants/entities/restaurant-schedule.entity.ts
@@ -1,4 +1,6 @@
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { DaysSchedule } from '@shared/modules/restaurants/enums/days-schedule.enum'
+
 import { Restaurant } from './restaurant.entity'
 
 @Entity('restaurant_schedules')
@@ -9,8 +11,8 @@ export class RestaurantSchedule {
   @ManyToOne(() => Restaurant, (restaurant) => restaurant.schedules)
   restaurant: Restaurant
 
-  @Column('varchar')
-  dayOfWeek: number
+  @Column('enum', { enum: DaysSchedule })
+  dayOfWeek: DaysSchedule
 
   @Column('time')
   openTime: string

--- a/api/src/modules/restaurants/entities/restaurant-staff-members.entity.ts
+++ b/api/src/modules/restaurants/entities/restaurant-staff-members.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
 import { RestaurantStaffMemberRole } from '@shared/modules/restaurants/enums/restaurant-staff-member-roles.enum'
 
 import { Restaurant } from './restaurant.entity'
@@ -25,6 +25,18 @@ export class RestaurantStaffMember {
 
   @Column('boolean', { default: true })
   isActive: boolean
+
+  @CreateDateColumn({
+    type: 'timestamp without time zone',
+    default: () => 'CURRENT_TIMESTAMP'
+  })
+  createdAt: Date
+
+  @UpdateDateColumn({
+    type: 'timestamp without time zone',
+    default: () => 'CURRENT_TIMESTAMP'
+  })
+  updatedAt: Date
 
   @ManyToOne(() => Restaurant, (restaurant) => restaurant.staffMembers)
   restaurant: Restaurant

--- a/api/src/modules/restaurants/entities/restaurant.entity.ts
+++ b/api/src/modules/restaurants/entities/restaurant.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
 import { RestaurantStatus } from '@shared/modules/restaurants/enums/restaurant.status.enum'
 
 import { User } from 'src/modules/users/entities/user.entity'
@@ -28,6 +28,18 @@ export class Restaurant {
 
   @Column('varchar', { nullable: true })
   logoUrl: string
+
+  @CreateDateColumn({
+    type: 'timestamp without time zone',
+    default: () => 'CURRENT_TIMESTAMP'
+  })
+  createdAt: Date
+
+  @UpdateDateColumn({
+    type: 'timestamp without time zone',
+    default: () => 'CURRENT_TIMESTAMP'
+  })
+  updatedAt: Date
 
   @ManyToOne(() => User, (user) => user.restaurants)
   @JoinColumn({ name: 'userId' })

--- a/api/src/modules/restaurants/helpers/schedule.helpers.ts
+++ b/api/src/modules/restaurants/helpers/schedule.helpers.ts
@@ -1,0 +1,70 @@
+export class ScheduleHelpers {
+  /**
+   * Verifica si hay solapamiento entre dos rangos de horarios
+   * Maneja correctamente los horarios que cruzan la medianoche
+   */
+  static hasTimeOverlap(schedule1: { openTime: string; closeTime: string }, schedule2: { openTime: string; closeTime: string }): boolean {
+    const [open1, close1] = [this.parseTime(schedule1.openTime), this.parseTime(schedule1.closeTime)]
+    const [open2, close2] = [this.parseTime(schedule2.openTime), this.parseTime(schedule2.closeTime)]
+
+    // Caso normal (sin cruce de medianoche)
+    if (open1 <= close1 && open2 <= close2) {
+      return !(close1 <= open2 || close2 <= open1)
+    }
+
+    // Caso con cruce de medianoche para schedule1
+    if (open1 > close1) {
+      return !(close1 <= open2 && close2 <= open1)
+    }
+
+    // Caso con cruce de medianoche para schedule2
+    if (open2 > close2) {
+      return !(close2 <= open1 && close1 <= open2)
+    }
+
+    return true
+  }
+
+  /**
+   * Convierte una hora en formato "HH:mm" a minutos desde medianoche
+   */
+  static parseTime(time: string): number {
+    const [hours, minutes] = time.split(':').map(Number)
+
+    return hours * 60 + minutes
+  }
+
+  /**
+   * Verifica si una hora está dentro del rango de un horario
+   * Maneja correctamente horarios que cruzan la medianoche
+   */
+  static isTimeInRange(targetTime: string, schedule: { openTime: string; closeTime: string }): boolean {
+    const target = this.parseTime(targetTime)
+    const open = this.parseTime(schedule.openTime)
+    const close = this.parseTime(schedule.closeTime)
+
+    // Caso normal (sin cruce de medianoche)
+    if (open <= close) {
+      return target >= open && target <= close
+    }
+
+    // Caso con cruce de medianoche
+    return target >= open || target <= close
+  }
+
+  /**
+   * Valida que la hora tenga el formato correcto "HH:mm"
+   */
+  static isValidTimeFormat(time: string): boolean {
+    const timeRegex = /^([0-1][0-9]|2[0-3]):[0-5][0-9]$/
+
+    return timeRegex.test(time)
+  }
+
+  /**
+   * Verifica si dos horarios son exactamente iguales
+   */
+  static areSchedulesEqual(schedule1: { openTime: string; closeTime: string; dayOfWeek: number }, schedule2: { openTime: string; closeTime: string; dayOfWeek: number }): boolean {
+    return schedule1.dayOfWeek === schedule2.dayOfWeek && schedule1.openTime === schedule2.openTime && schedule1.closeTime === schedule2.closeTime
+  }
+}

--- a/api/src/modules/restaurants/restaurants.controller.ts
+++ b/api/src/modules/restaurants/restaurants.controller.ts
@@ -1,4 +1,4 @@
-import { Post, Body, UseInterceptors, Controller, UploadedFile, Get, Query, Patch } from '@nestjs/common'
+import { Post, Body, UseInterceptors, Controller, UploadedFile, Get, Query, Patch, Delete } from '@nestjs/common'
 import { FileInterceptor } from '@nestjs/platform-express'
 import { ApiOperation, ApiBody, ApiConsumes, ApiTags, ApiBearerAuth, ApiHeader } from '@nestjs/swagger'
 import { UserRoles } from '@shared/modules/users/enums/roles.enum'
@@ -97,4 +97,13 @@ export class RestaurantsController {
   }
 
   // Métodos de eliminación
+  @Delete('delete-restaurant-schedule/:id')
+  @ApiBearerAuth()
+  @Roles(UserRoles.SuperAdmin, UserRoles.Tenant)
+  @ApiHeader({ name: 'x-refresh-token' })
+  @ApiHeader({ name: 'x-id-token' })
+  @ApiOperation({ summary: 'Eliminar un horario de un restaurante' })
+  async deleteRestaurantSchedule(@Query('id') id: string) {
+    return await this.restaurantsService.deleteSchedule(id)
+  }
 }

--- a/api/src/modules/restaurants/restaurants.controller.ts
+++ b/api/src/modules/restaurants/restaurants.controller.ts
@@ -72,6 +72,16 @@ export class RestaurantsController {
     return await this.restaurantsService.findAllStaff(id)
   }
 
+  @Get('find-all-schedules/:id')
+  @ApiBearerAuth()
+  @Roles(UserRoles.SuperAdmin, UserRoles.Tenant)
+  @ApiHeader({ name: 'x-refresh-token' })
+  @ApiHeader({ name: 'x-id-token' })
+  @ApiOperation({ summary: 'Obtener todos los horarios de un restaurante' })
+  async findAllSchedules(@UserId() userId: string, @Query('id') id: string) {
+    return await this.restaurantsService.findAllSchedules(userId, id)
+  }
+
   // Métodos de actualización
   @Patch('update/:id')
   @ApiBearerAuth()

--- a/api/src/modules/restaurants/restaurants.controller.ts
+++ b/api/src/modules/restaurants/restaurants.controller.ts
@@ -10,6 +10,7 @@ import { RestaurantsService } from './restaurants.service'
 import { CreateRestaurantRequestDto } from './dtos/create-restaurant-request.dto'
 import { UpdateRestaurantRequestDto } from './dtos/update-restaurant-request.dto'
 import { CreateStaffRequestDto } from './dtos/create-staff-request.dto'
+import { CreateRestaurantScheduleDto } from './dtos/create-restaurant-schedule.dto'
 
 @ApiTags('Restaurants')
 @Controller('restaurants')
@@ -38,6 +39,16 @@ export class RestaurantsController {
   @ApiOperation({ summary: 'Crear un miembro del staff para un restaurante' })
   async createStaff(@UserId() userId: string, @Body() body: CreateStaffRequestDto) {
     return await this.restaurantsService.createStaff(userId, body)
+  }
+
+  @Post('create-schedule/:id')
+  @ApiBearerAuth()
+  @Roles(UserRoles.SuperAdmin, UserRoles.Tenant)
+  @ApiHeader({ name: 'x-refresh-token' })
+  @ApiHeader({ name: 'x-id-token' })
+  @ApiOperation({ summary: 'Crear un horario para un restaurante' })
+  async createSchedule(@Query('id') id: string, @Body() body: CreateRestaurantScheduleDto) {
+    return await this.restaurantsService.createSchedule(id, body)
   }
 
   // Métodos de obtención

--- a/api/src/modules/restaurants/restaurants.service.ts
+++ b/api/src/modules/restaurants/restaurants.service.ts
@@ -5,6 +5,7 @@ import { RestaurantCodes, RestaurantMessages } from '@shared/modules/restaurants
 import { RestaurantStatus } from '@shared/modules/restaurants/enums/restaurant.status.enum'
 import { IFindAllRestaurantsResponse } from '@shared/modules/restaurants/interfaces/find-all-restaurants-response.interface'
 import { IFindAllStaffResponse } from '@shared/modules/restaurants/interfaces/find-all-staff-response.interface'
+import { IFindAllRestaurantsSchedule } from '@shared/modules/restaurants/interfaces/find-all-restaurants-schedule.interface'
 
 import { User } from 'src/modules/users/entities/user.entity'
 
@@ -403,6 +404,40 @@ export class RestaurantsService {
       message: RestaurantMessages[RestaurantCodes.SCHEDULE_CREATED].en,
       httpCode: HttpStatus.CREATED,
       data: schedule
+    }
+  }
+
+  async findAllSchedules(userId: string, restaurantId: string) {
+    this.logger.log(`Finding all schedules for restaurant: ${restaurantId}`)
+
+    const schedules = await this.restaurantScheduleRepository.find({ where: { restaurant: { id: restaurantId, user: { id: userId } } }, relations: ['restaurant'] })
+
+    if (schedules.length === 0) {
+      return {
+        success: false,
+        code: RestaurantCodes.SCHEDULES_NOT_FOUND,
+        message: RestaurantMessages[RestaurantCodes.SCHEDULES_NOT_FOUND].en,
+        httpCode: HttpStatus.NOT_FOUND,
+        data: []
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    this.logger.log(`Found ${schedules.length} schedules for restaurant: ${restaurantId}`)
+
+    const data: IFindAllRestaurantsSchedule[] = schedules.map((schedule) => ({
+      id: schedule.id,
+      dayOfWeek: schedule.dayOfWeek,
+      openTime: schedule.openTime,
+      closeTime: schedule.closeTime
+    }))
+
+    return {
+      success: true,
+      code: RestaurantCodes.SCHEDULES_FOUND,
+      message: RestaurantMessages[RestaurantCodes.SCHEDULES_FOUND].en,
+      httpCode: HttpStatus.OK,
+      data: data
     }
   }
 }

--- a/api/src/modules/restaurants/restaurants.service.ts
+++ b/api/src/modules/restaurants/restaurants.service.ts
@@ -440,4 +440,32 @@ export class RestaurantsService {
       data: data
     }
   }
+
+  async deleteSchedule(scheduleId: string) {
+    this.logger.log(`Deleting schedule with ID: ${scheduleId}`)
+
+    const schedule = await this.restaurantScheduleRepository.findOne({ where: { id: scheduleId } })
+
+    if (!schedule) {
+      return {
+        success: false,
+        code: RestaurantCodes.SCHEDULES_NOT_FOUND,
+        message: RestaurantMessages[RestaurantCodes.SCHEDULES_NOT_FOUND].en,
+        httpCode: HttpStatus.NOT_FOUND,
+        data: null
+      }
+    }
+
+    await this.restaurantScheduleRepository.remove(schedule)
+
+    this.logger.log('Schedule deleted')
+
+    return {
+      success: true,
+      code: RestaurantCodes.SCHEDULES_FOUND,
+      message: 'Schedule deleted successfully',
+      httpCode: HttpStatus.OK,
+      data: null
+    }
+  }
 }

--- a/api/src/modules/restaurants/restaurants.service.ts
+++ b/api/src/modules/restaurants/restaurants.service.ts
@@ -16,6 +16,9 @@ import { CreateRestaurantRequestDto } from './dtos/create-restaurant-request.dto
 import { UpdateRestaurantRequestDto } from './dtos/update-restaurant-request.dto'
 import { RestaurantStaffMember } from './entities/restaurant-staff-members.entity'
 import { CreateStaffRequestDto } from './dtos/create-staff-request.dto'
+import { RestaurantSchedule } from './entities/restaurant-schedule.entity'
+import { CreateRestaurantScheduleDto } from './dtos/create-restaurant-schedule.dto'
+import { ScheduleHelpers } from './helpers/schedule.helpers'
 
 @Injectable()
 export class RestaurantsService {
@@ -25,6 +28,8 @@ export class RestaurantsService {
   private readonly restaurantRepository: Repository<Restaurant>
   @InjectRepository(RestaurantStaffMember)
   private readonly staffRepository: Repository<RestaurantStaffMember>
+  @InjectRepository(RestaurantSchedule)
+  private readonly restaurantScheduleRepository: Repository<RestaurantSchedule>
 
   constructor(
     private readonly s3Service: S3Service,
@@ -315,5 +320,89 @@ export class RestaurantsService {
     const staff = await this.staffRepository.findOne({ where: { cognitoId } })
 
     return staff
+  }
+
+  // Métodos para los horarios
+  async createSchedule(restaurantId: string, body: CreateRestaurantScheduleDto) {
+    this.logger.log(`Creating schedule for restaurant ${restaurantId}`)
+
+    // Validar el formato de las horas
+    if (!ScheduleHelpers.isValidTimeFormat(body.openTime) || !ScheduleHelpers.isValidTimeFormat(body.closeTime)) {
+      return {
+        success: false,
+        code: RestaurantCodes.INVALID_SCHEDULE_FORMAT,
+        message: RestaurantMessages[RestaurantCodes.INVALID_SCHEDULE_FORMAT].en,
+        httpCode: HttpStatus.BAD_REQUEST,
+        data: null
+      }
+    }
+
+    const restaurant = await this.restaurantRepository.findOne({
+      where: { id: restaurantId },
+      relations: ['schedules']
+    })
+
+    if (!restaurant) {
+      return {
+        success: false,
+        code: RestaurantCodes.RESTAURANT_NOT_FOUND,
+        message: RestaurantMessages[RestaurantCodes.RESTAURANT_NOT_FOUND].en,
+        httpCode: HttpStatus.NOT_FOUND,
+        data: null
+      }
+    }
+
+    // Verificar si ya existe un horario para ese día
+    const existingSchedules = restaurant.schedules.filter((schedule) => schedule.dayOfWeek === body.dayOfWeek)
+
+    // Verificar solapamientos
+    const hasOverlap = existingSchedules.some((existingSchedule) =>
+      ScheduleHelpers.hasTimeOverlap({ openTime: body.openTime, closeTime: body.closeTime }, { openTime: existingSchedule.openTime, closeTime: existingSchedule.closeTime })
+    )
+
+    if (hasOverlap) {
+      return {
+        success: false,
+        code: RestaurantCodes.SCHEDULE_OVERLAP,
+        message: RestaurantMessages[RestaurantCodes.SCHEDULE_OVERLAP].en,
+        httpCode: HttpStatus.CONFLICT,
+        data: null
+      }
+    }
+
+    // Verificar duplicados exactos
+    const hasDuplicate = existingSchedules.some((existingSchedule) =>
+      ScheduleHelpers.areSchedulesEqual(
+        { dayOfWeek: body.dayOfWeek, openTime: body.openTime, closeTime: body.closeTime },
+        { dayOfWeek: existingSchedule.dayOfWeek, openTime: existingSchedule.openTime, closeTime: existingSchedule.closeTime }
+      )
+    )
+
+    if (hasDuplicate) {
+      return {
+        success: false,
+        code: RestaurantCodes.SCHEDULE_ALREADY_EXISTS,
+        message: RestaurantMessages[RestaurantCodes.SCHEDULE_ALREADY_EXISTS].en,
+        httpCode: HttpStatus.CONFLICT,
+        data: null
+      }
+    }
+
+    const schedule = this.restaurantScheduleRepository.create({
+      restaurant,
+      dayOfWeek: body.dayOfWeek,
+      openTime: body.openTime,
+      closeTime: body.closeTime
+    })
+
+    await this.restaurantScheduleRepository.save(schedule)
+
+    return {
+      success: true,
+      code: RestaurantCodes.SCHEDULE_CREATED,
+      message: RestaurantMessages[RestaurantCodes.SCHEDULE_CREATED].en,
+      httpCode: HttpStatus.CREATED,
+      data: schedule
+    }
   }
 }

--- a/shared/modules/restaurants/enums/days-schedule.enum.ts
+++ b/shared/modules/restaurants/enums/days-schedule.enum.ts
@@ -7,3 +7,13 @@ export enum DaysSchedule {
   FRIDAY = 5,
   SATURDAY = 6
 }
+
+export const DaysScheduleTranslate: Record<DaysSchedule, string> = {
+  [DaysSchedule.SUNDAY]: 'Domingo',
+  [DaysSchedule.MONDAY]: 'Lunes',
+  [DaysSchedule.TUESDAY]: 'Martes',
+  [DaysSchedule.WEDNESDAY]: 'Miércoles',
+  [DaysSchedule.THURSDAY]: 'Jueves',
+  [DaysSchedule.FRIDAY]: 'Viernes',
+  [DaysSchedule.SATURDAY]: 'Sábado'
+}

--- a/shared/modules/restaurants/enums/days-schedule.enum.ts
+++ b/shared/modules/restaurants/enums/days-schedule.enum.ts
@@ -1,0 +1,9 @@
+export enum DaysSchedule {
+  SUNDAY = 0,
+  MONDAY = 1,
+  TUESDAY = 2,
+  WEDNESDAY = 3,
+  THURSDAY = 4,
+  FRIDAY = 5,
+  SATURDAY = 6
+}

--- a/shared/modules/restaurants/interfaces/create-restaurants-schedule.inteface.ts
+++ b/shared/modules/restaurants/interfaces/create-restaurants-schedule.inteface.ts
@@ -1,0 +1,7 @@
+import { DaysSchedule } from '../enums/days-schedule.enum'
+
+export interface ICreateRestaurantScheduleInterface {
+  dayOfWeek: DaysSchedule
+  openTime: string
+  closeTime: string
+}

--- a/shared/modules/restaurants/interfaces/find-all-restaurants-schedule.interface.ts
+++ b/shared/modules/restaurants/interfaces/find-all-restaurants-schedule.interface.ts
@@ -1,0 +1,8 @@
+import { DaysSchedule } from '../enums/days-schedule.enum';
+
+export interface IFindAllRestaurantsSchedule {
+    id: string;
+    dayOfWeek: DaysSchedule;
+    openTime: string;
+    closeTime: string;
+}

--- a/shared/modules/restaurants/restaurants.contants.ts
+++ b/shared/modules/restaurants/restaurants.contants.ts
@@ -2,6 +2,8 @@ export enum RestaurantCodes {
   RESTAURANT_CREATED = 'RESTAURANT_CREATED',
   RESTAURANT_CREATED_WITHOUT_LOGO = 'RESTAURANT_CREATED_WITHOUT_LOGO',
   SCHEDULE_CREATED = 'SCHEDULE_CREATED',
+  SCHEDULES_FOUND = 'SCHEDULES_FOUND',
+  SCHEDULES_NOT_FOUND = 'SCHEDULES_NOT_FOUND',
   INVALID_SCHEDULE_FORMAT = 'INVALID_SCHEDULE_FORMAT',
   SCHEDULE_OVERLAP = 'SCHEDULE_OVERLAP',
   SCHEDULE_ALREADY_EXISTS = 'SCHEDULE_ALREADY_EXISTS',
@@ -49,6 +51,14 @@ export const RestaurantMessages: Record<RestaurantCodes, Record<string, string>>
   [RestaurantCodes.SCHEDULE_CREATED]: {
     en: 'Schedule created successfully',
     es: 'Horario creado exitosamente'
+  },
+  [RestaurantCodes.SCHEDULES_FOUND]: {
+    en: 'Schedules found for this restaurant',
+    es: 'Horarios encontrados para este restaurante'
+  },
+  [RestaurantCodes.SCHEDULES_NOT_FOUND]: {
+    en: 'No schedules found for this restaurant',
+    es: 'No se encontraron horarios para este restaurante'
   },
   [RestaurantCodes.RESTAURANT_UPDATED]: {
     en: 'Restaurant updated successfully',

--- a/shared/modules/restaurants/restaurants.contants.ts
+++ b/shared/modules/restaurants/restaurants.contants.ts
@@ -1,6 +1,10 @@
 export enum RestaurantCodes {
   RESTAURANT_CREATED = 'RESTAURANT_CREATED',
   RESTAURANT_CREATED_WITHOUT_LOGO = 'RESTAURANT_CREATED_WITHOUT_LOGO',
+  SCHEDULE_CREATED = 'SCHEDULE_CREATED',
+  INVALID_SCHEDULE_FORMAT = 'INVALID_SCHEDULE_FORMAT',
+  SCHEDULE_OVERLAP = 'SCHEDULE_OVERLAP',
+  SCHEDULE_ALREADY_EXISTS = 'SCHEDULE_ALREADY_EXISTS',
   RESTAURANT_UPDATED = 'RESTAURANT_UPDATED',
   RESTAURANT_UPDATED_WITHOUT_LOGO = 'RESTAURANT_UPDATED_WITHOUT_LOGO',
   RESTAURANT_DELETED = 'RESTAURANT_DELETED',
@@ -29,6 +33,22 @@ export const RestaurantMessages: Record<RestaurantCodes, Record<string, string>>
   [RestaurantCodes.RESTAURANT_CREATED_WITHOUT_LOGO]: {
     en: 'Restaurant created successfully but logo upload failed',
     es: 'Restaurante creado exitosamente pero falló la subida del logo'
+  },
+  [RestaurantCodes.INVALID_SCHEDULE_FORMAT]: {
+    en: 'Invalid schedule time format. Use HH:mm format (00:00-23:59)',
+    es: 'Formato de hora inválido. Use el formato HH:mm (00:00-23:59)'
+  },
+  [RestaurantCodes.SCHEDULE_OVERLAP]: {
+    en: 'Schedule overlaps with an existing schedule for this day',
+    es: 'El horario se solapa con un horario existente para este día'
+  },
+  [RestaurantCodes.SCHEDULE_ALREADY_EXISTS]: {
+    en: 'This schedule already exists for this day',
+    es: 'Este horario ya existe para este día'
+  },
+  [RestaurantCodes.SCHEDULE_CREATED]: {
+    en: 'Schedule created successfully',
+    es: 'Horario creado exitosamente'
   },
   [RestaurantCodes.RESTAURANT_UPDATED]: {
     en: 'Restaurant updated successfully',


### PR DESCRIPTION
- Creado métodos de creación, obtención y eliminación de horarios de un restaurante. (createSchedule, findAllSchedules y deleteSchedule)

- Se ajusto la entidad schedule para que los días se manejen bajo el enum DaysSchedule. también se creo un translate del enum.

- Se agrego los campos createdAt y updatedAt en las entidades RestaurantSchedule, RestaurantStaffMember y Restaurant para tener la trazabilidad de cuando se crearon y actualizaron. 

- Se creo el helper ScheduleHelpers que tiene como métodos hasTimeOverlap (Verifica si hay solapamiento entre dos rangos de horarios), parseTime (Convierte una hora en formato "HH:mm" a minutos desde medianoche), isTimeInRange (Verifica si una hora está dentro del rango de un horario), isValidTimeFormat (Valida que la hora tenga el formato correcto "HH:mm") y areSchedulesEqual (Verifica si dos horarios son exactamente iguales)